### PR TITLE
chore: clean CODEOWNERS + add entry for .github/agents

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,7 @@
 # CODEOWNERS documentation : https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/creating-a-repository-on-github/about-code-owners
 
+* @ContentSquare/ios
+
 # ==============
 # Platform stuff
 # ==============
@@ -10,6 +12,9 @@ Dockerfile* @ContentSquare/Platform
 
 # .github controls CODEOWNERS
 /.github/CODEOWNERS @ContentSquare/Platform
+
+# Protect .github/agents folder for GitHub Copilot agents
+/.github/agents/ @ContentSquare/ios
 
 # ==============
 # Platform stuff


### PR DESCRIPTION
## Description
Add a CODEOWNERS entry to protect the `.github/agents/` folder

## Motivation and Context
Proactively protect the GitHub agents folder so that when GitHub Copilot agent configurations are added, they will require review from the repository owners.

## Breaking Changes
No

## How Has This Been Tested?
N/A - CODEOWNERS configuration change only